### PR TITLE
feat: Add Policy/Trait/Belief/Building AdjacentImprovementYieldChanges

### DIFF
--- a/(1) CIV5MPDLL/DB/BUILDINGS/DLL_Buildings.sql
+++ b/(1) CIV5MPDLL/DB/BUILDINGS/DLL_Buildings.sql
@@ -468,3 +468,18 @@ create table Building_SpecificGreatPersonRateModifier (
 	SpecialistType text not null references Specialists(Type),
 	Modifier integer not null default 0
 );
+--******************** Adjacent Improvement Yield ********************--
+create table Building_AdjacentImprovementYieldChanges (
+    BuildingType text references Buildings(Type),
+    ImprovementType text references Improvements(Type),
+    OtherImprovementType text references Improvements(Type),
+    YieldType text references Yields(Type),
+    Yield integer default 0
+);
+create table Building_AdjacentImprovementYieldChangesGlobal (
+    BuildingType text references Buildings(Type),
+    ImprovementType text references Improvements(Type),
+    OtherImprovementType text references Improvements(Type),
+    YieldType text references Yields(Type),
+    Yield integer default 0
+);

--- a/(1) CIV5MPDLL/DB/POLICIES/DDL_Policies.sql
+++ b/(1) CIV5MPDLL/DB/POLICIES/DDL_Policies.sql
@@ -118,3 +118,11 @@ create table PolicyBranch_CivilizationLocked (
     PolicyBranchType text references PolicyBranchTypes(Type),
     CivilizationType text references Civilizations(Type)
 );
+--******************** Adjacent Improvement Yield ********************--
+create table Policy_AdjacentImprovementYieldChanges (
+    PolicyType text references Policies(Type),
+    ImprovementType text references Improvements(Type),
+    OtherImprovementType text references Improvements(Type),
+    YieldType text references Yields(Type),
+    Yield integer default 0
+);

--- a/(1) CIV5MPDLL/DB/RELIGION/Belief_Table_Changes.sql
+++ b/(1) CIV5MPDLL/DB/RELIGION/Belief_Table_Changes.sql
@@ -48,6 +48,13 @@ create table Belief_ImprovementAdjacentCityYieldChanges (
     YieldType text references Yields(Type),
     Yield integer default 0
 );
+create table Belief_AdjacentImprovementYieldChanges (
+    BeliefType text references Beliefs(Type),
+    ImprovementType text references Improvements(Type),
+    OtherImprovementType text references Improvements(Type),
+    YieldType text references Yields(Type),
+    Yield integer default 0
+);
 --Need define Belief_MaxYieldModifierPerFollower before use this, Actual value = 100 + Modifier
 create table Belief_YieldModifierPerFollowerTimes100 (
     BeliefType text references Beliefs(Type),

--- a/(1) CIV5MPDLL/DB/TRAITS/DDL_Traits.sql
+++ b/(1) CIV5MPDLL/DB/TRAITS/DDL_Traits.sql
@@ -110,3 +110,11 @@ alter table Civilizations add SpecialGAText text default 'TXT_KEY_GOLDEN_AGE_ANN
 alter table Civilizations add SpecialGAHelpText text default 'TXT_KEY_TP_GOLDEN_AGE_EFFECT';
 alter table Traits add NaturalWonderYieldModifierPerEra int default 0;
 alter table Traits add GoldenAgeTechChainBoost boolean default 0;
+--******************** Adjacent Improvement Yield ********************--
+create table Trait_AdjacentImprovementYieldChanges (
+    TraitType text references Traits(Type),
+    ImprovementType text references Improvements(Type),
+    OtherImprovementType text references Improvements(Type),
+    YieldType text references Yields(Type),
+    Yield integer default 0
+);

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -1175,6 +1175,33 @@ bool CvBeliefEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 			m_ppiImprovementYieldChanges[ImprovementID][YieldID] = yield;
 		}
 	}
+	//AdjacentImprovementYieldChanges
+	{
+		std::string strKey("Belief_AdjacentImprovementYieldChanges");
+		Database::Results* pResults = kUtility.GetResults(strKey);
+		if (pResults == NULL)
+		{
+			pResults = kUtility.PrepareResults(strKey,
+				"SELECT Imp1.ID as ImprovementID, Imp2.ID as OtherImprovementID, "
+				"Yields.ID as YieldID, Yield "
+				"FROM Belief_AdjacentImprovementYieldChanges "
+				"INNER JOIN Improvements AS Imp1 ON ImprovementType = Imp1.Type "
+				"INNER JOIN Improvements AS Imp2 ON OtherImprovementType = Imp2.Type "
+				"INNER JOIN Yields ON YieldType = Yields.Type "
+				"WHERE BeliefType = ?");
+		}
+		pResults->Bind(1, szBeliefType);
+		while (pResults->Step())
+		{
+			AdjacentImprovementYieldChange change;
+			change.m_iImprovementType = pResults->GetInt(0);
+			change.m_iOtherImprovementType = pResults->GetInt(1);
+			change.m_iYieldType = pResults->GetInt(2);
+			change.m_iYield = pResults->GetInt(3);
+			m_vAdjacentImprovementYieldChanges.push_back(change);
+		}
+		pResults->Reset();
+	}
 	//ImprovementAdjacentCityYieldChanges;
 	{
 		kUtility.Initialize2DArray(m_ppiImprovementAdjacentCityYieldChanges, "Improvements", "Yields");
@@ -2184,6 +2211,31 @@ int CvReligionBeliefs::GetImprovementYieldChange(ImprovementTypes eImprovement, 
 int CvReligionBeliefs::GetImprovementAdjacentCityYieldChange(ImprovementTypes eImprovement, YieldTypes eYield) const
 {
 	return m_vImprovementAdjacentCityYieldChanges[eImprovement][eYield];
+}
+
+/// Get adjacent improvement yield change from beliefs
+int CvReligionBeliefs::GetAdjacentImprovementYieldChange(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const
+{
+	int rtnValue = 0;
+	CvBeliefXMLEntries* pBeliefs = GC.GetGameBeliefs();
+	for (BeliefList::const_iterator i = m_ReligionBeliefs.begin(); i != m_ReligionBeliefs.end(); ++i)
+	{
+		CvBeliefEntry* pBeliefEntry = pBeliefs->GetEntry(*i);
+		if (pBeliefEntry)
+		{
+			const auto& vChanges = pBeliefEntry->GetAdjacentImprovementYieldChanges();
+			for (const auto& change : vChanges)
+			{
+				if ((int)change.m_iImprovementType == (int)eImprovement &&
+					(int)change.m_iOtherImprovementType == (int)eOtherImprovement &&
+					(int)change.m_iYieldType == (int)eYield)
+				{
+					rtnValue += change.m_iYield;
+				}
+			}
+		}
+	}
+	return rtnValue;
 }
 
 /// Get yield change from beliefs for a specific building class

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -104,6 +104,15 @@ public:
 	int GetResourceQuantityModifier(int i) const;
 	int GetImprovementYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2) const;
 	int GetImprovementAdjacentCityYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2) const;
+
+	// AdjacentImprovementYieldChanges
+	struct AdjacentImprovementYieldChange {
+		int m_iImprovementType;
+		int m_iOtherImprovementType;
+		int m_iYieldType;
+		int m_iYield;
+	};
+	const std::vector<AdjacentImprovementYieldChange>& GetAdjacentImprovementYieldChanges() const { return m_vAdjacentImprovementYieldChanges; }
 	int GetBuildingClassYieldChange(int i, int j) const;
 	int GetBuildingClassHappiness(int i) const;
 	int GetBuildingClassTourism(int i) const;
@@ -308,6 +317,9 @@ protected:
 	bool* m_pbFaithPurchaseUnitEraEnabled;
     bool* m_pbBuildingClassEnabled;
 
+
+	// AdjacentImprovementYieldChanges
+	std::vector<AdjacentImprovementYieldChange> m_vAdjacentImprovementYieldChanges;
 private:
 	CvBeliefEntry(const CvBeliefEntry&);
 	CvBeliefEntry& operator=(const CvBeliefEntry&);
@@ -564,6 +576,7 @@ public:
 	int GetResourceQuantityModifier(ResourceTypes eResource) const;
 	int GetImprovementYieldChange(ImprovementTypes eImprovement, YieldTypes eYield) const;
 	int GetImprovementAdjacentCityYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2) const;
+	int GetAdjacentImprovementYieldChange(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const;
 	int GetBuildingClassYieldChange(BuildingClassTypes eBuildingClass, YieldTypes eYieldType, int iFollowers) const;
 	int GetBuildingClassHappiness(BuildingClassTypes eBuildingClass, int iFollowers) const;
 	int GetBuildingClassTourism(BuildingClassTypes eBuildingClass) const;

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -1232,6 +1232,60 @@ bool CvBuildingEntry::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 			m_ppaiImprovementYieldChange[ImprovementID][YieldID] = yield;
 		}
 	}
+	//AdjacentImprovementYieldChanges
+	{
+		std::string strKey("Building_AdjacentImprovementYieldChanges");
+		Database::Results* pResults = kUtility.GetResults(strKey);
+		if (pResults == NULL)
+		{
+			pResults = kUtility.PrepareResults(strKey,
+				"SELECT Imp1.ID as ImprovementID, Imp2.ID as OtherImprovementID, "
+				"Yields.ID as YieldID, Yield "
+				"FROM Building_AdjacentImprovementYieldChanges "
+				"INNER JOIN Improvements AS Imp1 ON ImprovementType = Imp1.Type "
+				"INNER JOIN Improvements AS Imp2 ON OtherImprovementType = Imp2.Type "
+				"INNER JOIN Yields ON YieldType = Yields.Type "
+				"WHERE BuildingType = ?");
+		}
+		pResults->Bind(1, szBuildingType);
+		while (pResults->Step())
+		{
+			AdjacentImprovementYieldChange change;
+			change.m_iImprovementType = pResults->GetInt(0);
+			change.m_iOtherImprovementType = pResults->GetInt(1);
+			change.m_iYieldType = pResults->GetInt(2);
+			change.m_iYield = pResults->GetInt(3);
+			m_vAdjacentImprovementYieldChanges.push_back(change);
+		}
+		pResults->Reset();
+	}
+	//AdjacentImprovementYieldChangesGlobal
+	{
+		std::string strKey("Building_AdjacentImprovementYieldChangesGlobal");
+		Database::Results* pResults = kUtility.GetResults(strKey);
+		if (pResults == NULL)
+		{
+			pResults = kUtility.PrepareResults(strKey,
+				"SELECT Imp1.ID as ImprovementID, Imp2.ID as OtherImprovementID, "
+				"Yields.ID as YieldID, Yield "
+				"FROM Building_AdjacentImprovementYieldChangesGlobal "
+				"INNER JOIN Improvements AS Imp1 ON ImprovementType = Imp1.Type "
+				"INNER JOIN Improvements AS Imp2 ON OtherImprovementType = Imp2.Type "
+				"INNER JOIN Yields ON YieldType = Yields.Type "
+				"WHERE BuildingType = ?");
+		}
+		pResults->Bind(1, szBuildingType);
+		while (pResults->Step())
+		{
+			AdjacentImprovementYieldChange change;
+			change.m_iImprovementType = pResults->GetInt(0);
+			change.m_iOtherImprovementType = pResults->GetInt(1);
+			change.m_iYieldType = pResults->GetInt(2);
+			change.m_iYield = pResults->GetInt(3);
+			m_vAdjacentImprovementYieldChangesGlobal.push_back(change);
+		}
+		pResults->Reset();
+	}
 	//ImprovementYieldChangesGlobal
 	{
 		kUtility.Initialize2DArray(m_ppaiImprovementYieldChangeGlobal, "Improvements", "Yields");

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -4677,6 +4677,7 @@ bool CvBuildingEntry::IsOriginalCapitalOnly() const
 //=====================================
 /// Constructor
 CvBuildingXMLEntries::CvBuildingXMLEntries(void)
+	: m_bAdjacentYieldCacheBuilt(false)
 {
 
 }
@@ -4708,6 +4709,9 @@ void CvBuildingXMLEntries::DeleteArray()
 	}
 
 	m_paBuildingEntries.clear();
+	m_vAdjacentYieldBuildingTypes.clear();
+	m_vAdjacentYieldGlobalBuildingTypes.clear();
+	m_bAdjacentYieldCacheBuilt = false;
 }
 
 /// Get a specific entry
@@ -4715,6 +4719,36 @@ CvBuildingEntry* CvBuildingXMLEntries::GetEntry(int index)
 {
 	if (index < 0) return nullptr;
 	return m_paBuildingEntries[index];
+}
+
+/// Lazy-build cached list of building types with adjacent yield entries
+void CvBuildingXMLEntries::BuildAdjacentYieldCache() const
+{
+	if (m_bAdjacentYieldCacheBuilt) return;
+	for (size_t i = 0; i < m_paBuildingEntries.size(); i++)
+	{
+		CvBuildingEntry* pEntry = m_paBuildingEntries[i];
+		if (pEntry)
+		{
+			if (!pEntry->GetAdjacentImprovementYieldChanges().empty())
+				m_vAdjacentYieldBuildingTypes.push_back((BuildingTypes)i);
+			if (!pEntry->GetAdjacentImprovementYieldChangesGlobal().empty())
+				m_vAdjacentYieldGlobalBuildingTypes.push_back((BuildingTypes)i);
+		}
+	}
+	m_bAdjacentYieldCacheBuilt = true;
+}
+
+const std::vector<BuildingTypes>& CvBuildingXMLEntries::GetBuildingsWithAdjacentYield() const
+{
+	BuildAdjacentYieldCache();
+	return m_vAdjacentYieldBuildingTypes;
+}
+
+const std::vector<BuildingTypes>& CvBuildingXMLEntries::GetBuildingsWithAdjacentYieldGlobal() const
+{
+	BuildAdjacentYieldCache();
+	return m_vAdjacentYieldGlobalBuildingTypes;
 }
 
 //=====================================

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -280,6 +280,16 @@ public:
 	int GetImprovementYieldChangeGlobal(int i, int j) const;
 	int* GetImprovementYieldChangeGlobalArray(int i) const;
 
+	// AdjacentImprovementYieldChanges
+	struct AdjacentImprovementYieldChange {
+		int m_iImprovementType;
+		int m_iOtherImprovementType;
+		int m_iYieldType;
+		int m_iYield;
+	};
+	const std::vector<AdjacentImprovementYieldChange>& GetAdjacentImprovementYieldChanges() const { return m_vAdjacentImprovementYieldChanges; }
+	const std::vector<AdjacentImprovementYieldChange>& GetAdjacentImprovementYieldChangesGlobal() const { return m_vAdjacentImprovementYieldChangesGlobal; }
+
 	int GetFeatureYieldChangesGlobal(int i, int j) const;
 	int GetTerrainYieldChangesGlobal(int i, int j) const;
 
@@ -1069,6 +1079,10 @@ private:
 
 	std::tr1::array<int, YieldTypes::NUM_YIELD_TYPES> m_aTradeRouteFromTheCityYields;
 	std::tr1::array<int, YieldTypes::NUM_YIELD_TYPES> m_aTradeRouteFromTheCityYieldsPerEra;
+
+	// AdjacentImprovementYieldChanges
+	std::vector<AdjacentImprovementYieldChange> m_vAdjacentImprovementYieldChanges;
+	std::vector<AdjacentImprovementYieldChange> m_vAdjacentImprovementYieldChangesGlobal;
 };
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -1109,8 +1109,17 @@ public:
 
 	void DeleteArray();
 
+	// Cached building types with adjacent improvement yield entries
+	const std::vector<BuildingTypes>& GetBuildingsWithAdjacentYield() const;
+	const std::vector<BuildingTypes>& GetBuildingsWithAdjacentYieldGlobal() const;
+
 private:
+	void BuildAdjacentYieldCache() const;
+
 	std::vector<CvBuildingEntry*> m_paBuildingEntries;
+	mutable std::vector<BuildingTypes> m_vAdjacentYieldBuildingTypes;
+	mutable std::vector<BuildingTypes> m_vAdjacentYieldGlobalBuildingTypes;
+	mutable bool m_bAdjacentYieldCacheBuilt;
 };
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -3823,11 +3823,13 @@ int CvCity::GetAdjacentImprovementYieldChangeFromBuildings(ImprovementTypes eImp
 {
 	VALIDATE_OBJECT
 	int rtnValue = 0;
-	for (int i = 0; i < GC.getNumBuildingInfos(); i++)
+	const std::vector<BuildingTypes>& vCached = GC.GetGameBuildings()->GetBuildingsWithAdjacentYield();
+	for (size_t i = 0; i < vCached.size(); i++)
 	{
-		if (GetCityBuildings()->GetNumActiveBuilding((BuildingTypes)i) > 0)
+		BuildingTypes eBuilding = vCached[i];
+		if (GetCityBuildings()->GetNumActiveBuilding(eBuilding) > 0)
 		{
-			CvBuildingEntry* pBuilding = GC.getBuildingInfo((BuildingTypes)i);
+			CvBuildingEntry* pBuilding = GC.getBuildingInfo(eBuilding);
 			if (pBuilding)
 			{
 				const auto& vChanges = pBuilding->GetAdjacentImprovementYieldChanges();

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -3818,6 +3818,35 @@ int CvCity::GetImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes e
 }
 
 //	--------------------------------------------------------------------------------
+/// Get adjacent improvement yield change from buildings in this city
+int CvCity::GetAdjacentImprovementYieldChangeFromBuildings(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const
+{
+	VALIDATE_OBJECT
+	int rtnValue = 0;
+	for (int i = 0; i < GC.getNumBuildingInfos(); i++)
+	{
+		if (GetCityBuildings()->GetNumActiveBuilding((BuildingTypes)i) > 0)
+		{
+			CvBuildingEntry* pBuilding = GC.getBuildingInfo((BuildingTypes)i);
+			if (pBuilding)
+			{
+				const auto& vChanges = pBuilding->GetAdjacentImprovementYieldChanges();
+				for (const auto& change : vChanges)
+				{
+					if ((int)change.m_iImprovementType == (int)eImprovement &&
+						(int)change.m_iOtherImprovementType == (int)eOtherImprovement &&
+						(int)change.m_iYieldType == (int)eYield)
+					{
+						rtnValue += change.m_iYield;
+					}
+				}
+			}
+		}
+	}
+	return rtnValue;
+}
+
+//	--------------------------------------------------------------------------------
 void CvCity::ChangeImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes eYield, int iChange)
 {
 	VALIDATE_OBJECT

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -190,6 +190,7 @@ public:
 
 	int GetImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes eYield) const;
 	void ChangeImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes eYield, int iChange);
+	int GetAdjacentImprovementYieldChangeFromBuildings(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const;
 
 #if defined(MOD_ROG_CORE)
 	int GetYieldPerXFeature(FeatureTypes eFeature, YieldTypes eYield) const;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -21318,6 +21318,39 @@ int CvPlayer::GetImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes
 }
 
 //	--------------------------------------------------------------------------------
+/// Get adjacent improvement yield change from buildings with Global scope (any city in the empire)
+int CvPlayer::GetAdjacentImprovementYieldChangeFromBuildingsGlobal(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const
+{
+	int rtnValue = 0;
+	int iNumBuildings = GC.getNumBuildingInfos();
+	int iLoop = 0;
+	for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
+	{
+		for (int i = 0; i < iNumBuildings; i++)
+		{
+			if (pLoopCity->GetCityBuildings()->GetNumActiveBuilding((BuildingTypes)i) > 0)
+			{
+				CvBuildingEntry* pBuilding = GC.getBuildingInfo((BuildingTypes)i);
+				if (pBuilding)
+				{
+					const auto& vChanges = pBuilding->GetAdjacentImprovementYieldChangesGlobal();
+					for (const auto& change : vChanges)
+					{
+						if ((int)change.m_iImprovementType == (int)eImprovement &&
+							(int)change.m_iOtherImprovementType == (int)eOtherImprovement &&
+							(int)change.m_iYieldType == (int)eYield)
+						{
+							rtnValue += change.m_iYield;
+						}
+					}
+				}
+			}
+		}
+	}
+	return rtnValue;
+}
+
+//	--------------------------------------------------------------------------------
 void CvPlayer::ChangeImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes eYield, int iChange)
 {
 	CvAssertMsg(eImprovement >= 0, "eIndex1 is expected to be non-negative (invalid Index)");
@@ -34048,4 +34081,4 @@ UnitTypes CvPlayer::GetCivUnitWithDefault(UnitClassTypes eUnitClass) const
 		if(pUnitClassInfo) eUnitType = (UnitTypes)pUnitClassInfo->getDefaultUnitIndex();
 	}
 	return eUnitType;
-}
+}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -21322,15 +21322,16 @@ int CvPlayer::GetImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes
 int CvPlayer::GetAdjacentImprovementYieldChangeFromBuildingsGlobal(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const
 {
 	int rtnValue = 0;
-	int iNumBuildings = GC.getNumBuildingInfos();
 	int iLoop = 0;
+	const std::vector<BuildingTypes>& vCached = GC.GetGameBuildings()->GetBuildingsWithAdjacentYieldGlobal();
 	for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
-		for (int i = 0; i < iNumBuildings; i++)
+		for (size_t i = 0; i < vCached.size(); i++)
 		{
-			if (pLoopCity->GetCityBuildings()->GetNumActiveBuilding((BuildingTypes)i) > 0)
+			BuildingTypes eBuilding = vCached[i];
+			if (pLoopCity->GetCityBuildings()->GetNumActiveBuilding(eBuilding) > 0)
 			{
-				CvBuildingEntry* pBuilding = GC.getBuildingInfo((BuildingTypes)i);
+				CvBuildingEntry* pBuilding = GC.getBuildingInfo(eBuilding);
 				if (pBuilding)
 				{
 					const auto& vChanges = pBuilding->GetAdjacentImprovementYieldChangesGlobal();

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1362,6 +1362,7 @@ public:
 
 	int GetImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes eYield) const;
 	void ChangeImprovementExtraYield(ImprovementTypes eImprovement, YieldTypes eYield, int iChange);
+	int GetAdjacentImprovementYieldChangeFromBuildingsGlobal(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const;
 
 	int GetYieldModifierFromSpecialistGlobal(SpecialistTypes eSpecialist, YieldTypes eYield) const;
 	void ChangeYieldModifierFromSpecialistGlobal(SpecialistTypes eSpecialist, YieldTypes eYield, int iChange);

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -9155,6 +9155,25 @@ int CvPlot::calculateImprovementYieldChange(ImprovementTypes eImprovement, Yield
 #if defined(MOD_API_VP_ADJACENT_YIELD_BOOST)
 		iYield += ComputeYieldFromOtherAdjacentImprovement(*pImprovement, eYield);
 #endif
+		// Policy and Trait adjacent improvement yield bonuses
+		{
+			CvPlayerAI& kPlayer = GET_PLAYER(ePlayer);
+			for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+			{
+				CvPlot* pAdjacentPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
+				if (pAdjacentPlot && pAdjacentPlot->getImprovementType() != NO_IMPROVEMENT
+					&& pAdjacentPlot->getOwner() == ePlayer)
+				{
+					ImprovementTypes eOtherImp = pAdjacentPlot->getImprovementType();
+					iYield += kPlayer.GetPlayerPolicies()->GetAdjacentImprovementYieldChange(
+						eImprovement, eOtherImp, eYield);
+					iYield += kPlayer.GetPlayerTraits()->GetAdjacentImprovementYieldChange(
+						eImprovement, eOtherImp, eYield);
+					iYield += kPlayer.GetAdjacentImprovementYieldChangeFromBuildingsGlobal(
+						eImprovement, eOtherImp, eYield);
+				}
+			}
+		}
 	}
 	if(eYield == YIELD_CULTURE && getOwner() != NO_PLAYER)
 	{
@@ -9350,11 +9369,52 @@ int CvPlot::calculateImprovementYieldChange(ImprovementTypes eImprovement, Yield
 					iReligionAdjacentCityYield += GC.GetGameBeliefs()->GetEntry(eSecondaryPantheon)->GetImprovementAdjacentCityYieldChange(eImprovement, eYield);
 				}
 				iYield += iReligionChange;
+				// Belief adjacent improvement yield bonuses
+				for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+				{
+					CvPlot* pAdjacentPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
+					if (pAdjacentPlot && pAdjacentPlot->getImprovementType() != NO_IMPROVEMENT)
+					{
+						ImprovementTypes eOtherImp = pAdjacentPlot->getImprovementType();
+						iYield += pReligion->m_Beliefs.GetAdjacentImprovementYieldChange(
+							eImprovement, eOtherImp, eYield);
+						if (eSecondaryPantheon != NO_BELIEF)
+						{
+							CvBeliefEntry* pSecBelief = GC.GetGameBeliefs()->GetEntry(eSecondaryPantheon);
+							if (pSecBelief)
+							{
+								const auto& vChanges = pSecBelief->GetAdjacentImprovementYieldChanges();
+								for (const auto& change : vChanges)
+								{
+									if ((int)change.m_iImprovementType == (int)eImprovement &&
+										(int)change.m_iOtherImprovementType == (int)eOtherImp &&
+										(int)change.m_iYieldType == (int)eYield)
+									{
+										iYield += change.m_iYield;
+									}
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 		
 		// Extra yield for improvements
 		iYield += pWorkingCity->GetImprovementExtraYield(eImprovement, eYield);
+			// Building adjacent improvement yield bonuses
+			{
+				for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+				{
+					CvPlot* pAdjacentPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
+					if (pAdjacentPlot && pAdjacentPlot->getImprovementType() != NO_IMPROVEMENT)
+					{
+						ImprovementTypes eOtherImp = pAdjacentPlot->getImprovementType();
+						iYield += pWorkingCity->GetAdjacentImprovementYieldChangeFromBuildings(
+							eImprovement, eOtherImp, eYield);
+					}
+				}
+			}
 		if(ePlayer != NO_PLAYER) iYield += GET_PLAYER(ePlayer).GetImprovementExtraYield(eImprovement, eYield);
 	}
 
@@ -14168,4 +14228,4 @@ int CvPlot::GetNumSpecificPlayerUnitsAdjacent(PlayerTypes ePlayer, const CvUnit*
 	return iNumUnitsAdjacent;
 }
 
-#endif
+#endif

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -742,6 +742,34 @@ bool CvPolicyEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 		}
 	}
 
+	//AdjacentImprovementYieldChanges
+	{
+		std::string strKey("Policy_AdjacentImprovementYieldChanges");
+		Database::Results* pResults = kUtility.GetResults(strKey);
+		if (pResults == NULL)
+		{
+			pResults = kUtility.PrepareResults(strKey,
+				"SELECT Imp1.ID as ImprovementID, Imp2.ID as OtherImprovementID, "
+				"Yields.ID as YieldID, Yield "
+				"FROM Policy_AdjacentImprovementYieldChanges "
+				"INNER JOIN Improvements AS Imp1 ON ImprovementType = Imp1.Type "
+				"INNER JOIN Improvements AS Imp2 ON OtherImprovementType = Imp2.Type "
+				"INNER JOIN Yields ON YieldType = Yields.Type "
+				"WHERE PolicyType = ?");
+		}
+		pResults->Bind(1, szPolicyType);
+		while (pResults->Step())
+		{
+			AdjacentImprovementYieldChange change;
+			change.m_iImprovementType = pResults->GetInt(0);
+			change.m_iOtherImprovementType = pResults->GetInt(1);
+			change.m_iYieldType = pResults->GetInt(2);
+			change.m_iYield = pResults->GetInt(3);
+			m_vAdjacentImprovementYieldChanges.push_back(change);
+		}
+		pResults->Reset();
+	}
+
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)
 	//PlotYieldChanges
 	if (MOD_API_UNIFIED_YIELDS && MOD_API_PLOT_YIELDS)
@@ -3928,6 +3956,31 @@ int CvPlayerPolicies::GetImprovementCultureChange(ImprovementTypes eImprovement)
 		if(m_pabHasPolicy[i] && !IsPolicyBlocked((PolicyTypes)i))
 		{
 			rtnValue += m_pPolicies->GetPolicyEntry(i)->GetImprovementCultureChanges(eImprovement);
+		}
+	}
+
+	return rtnValue;
+}
+
+/// Get adjacent improvement yield change from policies
+int CvPlayerPolicies::GetAdjacentImprovementYieldChange(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield)
+{
+	int rtnValue = 0;
+
+	for (int i = 0; i < m_pPolicies->GetNumPolicies(); i++)
+	{
+		if (m_pabHasPolicy[i] && !IsPolicyBlocked((PolicyTypes)i))
+		{
+			const auto& vChanges = m_pPolicies->GetPolicyEntry(i)->GetAdjacentImprovementYieldChanges();
+			for (const auto& change : vChanges)
+			{
+				if ((int)change.m_iImprovementType == (int)eImprovement &&
+					(int)change.m_iOtherImprovementType == (int)eOtherImprovement &&
+					(int)change.m_iYieldType == (int)eYield)
+				{
+					rtnValue += change.m_iYield;
+				}
+			}
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -271,6 +271,15 @@ public:
 	int GetTourismByUnitClassCreated(int i) const;
 	int GetImprovementCultureChanges(int i) const;
 
+	// AdjacentImprovementYieldChanges
+	struct AdjacentImprovementYieldChange {
+		int m_iImprovementType;
+		int m_iOtherImprovementType;
+		int m_iYieldType;
+		int m_iYield;
+	};
+	const std::vector<AdjacentImprovementYieldChange>& GetAdjacentImprovementYieldChanges() const { return m_vAdjacentImprovementYieldChanges; }
+
 	int GetHurryModifier(int i) const;
 	bool IsSpecialistValid(int i) const;
 	int GetImprovementYieldChanges(int i, int j) const;
@@ -674,6 +683,9 @@ private:
 
 	std::vector<PolicyResourceInfo> m_vCityResources;
 
+	// AdjacentImprovementYieldChanges
+	std::vector<AdjacentImprovementYieldChange> m_vAdjacentImprovementYieldChanges;
+
 #ifdef MOD_GLOBAL_CORRUPTION
 	int m_iCorruptionScoreModifier = 0;
 	bool m_bCorruptionLevelReduceByOne = false;
@@ -825,6 +837,7 @@ public:
 	int GetBuildingClassProductionModifier(BuildingClassTypes eBuildingClass);
 	int GetBuildingClassTourismModifier(BuildingClassTypes eBuildingClass);
 	int GetImprovementCultureChange(ImprovementTypes eImprovement);
+	int GetAdjacentImprovementYieldChange(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield);
 	bool HasPolicyEncouragingGarrisons() const;
 	bool HasPolicyGrantingReformationBelief() const;
 	CvString GetWeLoveTheKingString();

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -2130,6 +2130,33 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 			m_ppiImprovementYieldChanges[ImprovementID][YieldID] = yield;
 		}
 	}
+	//AdjacentImprovementYieldChanges
+	{
+		std::string strKey("Trait_AdjacentImprovementYieldChanges");
+		Database::Results* pResults = kUtility.GetResults(strKey);
+		if (pResults == NULL)
+		{
+			pResults = kUtility.PrepareResults(strKey,
+				"SELECT Imp1.ID as ImprovementID, Imp2.ID as OtherImprovementID, "
+				"Yields.ID as YieldID, Yield "
+				"FROM Trait_AdjacentImprovementYieldChanges "
+				"INNER JOIN Improvements AS Imp1 ON ImprovementType = Imp1.Type "
+				"INNER JOIN Improvements AS Imp2 ON OtherImprovementType = Imp2.Type "
+				"INNER JOIN Yields ON YieldType = Yields.Type "
+				"WHERE TraitType = ?");
+		}
+		pResults->Bind(1, szTraitType);
+		while (pResults->Step())
+		{
+			AdjacentImprovementYieldChange change;
+			change.m_iImprovementType = pResults->GetInt(0);
+			change.m_iOtherImprovementType = pResults->GetInt(1);
+			change.m_iYieldType = pResults->GetInt(2);
+			change.m_iYield = pResults->GetInt(3);
+			m_vAdjacentImprovementYieldChanges.push_back(change);
+		}
+		pResults->Reset();
+	}
 
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)
 	//PlotYieldChanges
@@ -3754,6 +3781,33 @@ int CvPlayerTraits::GetImprovementYieldChange(ImprovementTypes eImprovement, Yie
 	}
 
 	return m_ppaaiImprovementYieldChange[(int)eImprovement][(int)eYield];
+}
+
+/// Get adjacent improvement yield change from traits
+int CvPlayerTraits::GetAdjacentImprovementYieldChange(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const
+{
+	int rtnValue = 0;
+	for (int i = 0; i < GC.getNumTraitInfos(); i++)
+	{
+		if (HasTrait((TraitTypes)i))
+		{
+			CvTraitEntry* pTrait = GC.getTraitInfo((TraitTypes)i);
+			if (pTrait)
+			{
+				const auto& vChanges = pTrait->GetAdjacentImprovementYieldChanges();
+				for (const auto& change : vChanges)
+				{
+					if ((int)change.m_iImprovementType == (int)eImprovement &&
+						(int)change.m_iOtherImprovementType == (int)eOtherImprovement &&
+						(int)change.m_iYieldType == (int)eYield)
+					{
+						rtnValue += change.m_iYield;
+					}
+				}
+			}
+		}
+	}
+	return rtnValue;
 }
 
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.h
@@ -266,6 +266,16 @@ public:
 	int GetUnimprovedFeatureYieldChanges(FeatureTypes eIndex1, YieldTypes eIndex2) const;
 	int GetCityYieldModifierFromAdjacentFeature(FeatureTypes eIndex1, YieldTypes eIndex2) const;
 	int GetCityYieldPerAdjacentFeature(FeatureTypes eIndex1, YieldTypes eIndex2) const;
+
+	// AdjacentImprovementYieldChanges
+	struct AdjacentImprovementYieldChange {
+		int m_iImprovementType;
+		int m_iOtherImprovementType;
+		int m_iYieldType;
+		int m_iYield;
+	};
+	const std::vector<AdjacentImprovementYieldChange>& GetAdjacentImprovementYieldChanges() const { return m_vAdjacentImprovementYieldChanges; }
+
 	FreeResourceXCities GetFreeResourceXCities(ResourceTypes eResource) const;
 
 	bool IsFreePromotionUnitCombat(const int promotionID, const int unitCombatID) const;
@@ -613,6 +623,10 @@ protected:
 	int m_iShareAllyResearchPercent = 0;
 	bool m_bCanPurchaseWonderInGoldenAge = false;
 	bool m_bCanDiplomaticMarriage = false;
+
+	// AdjacentImprovementYieldChanges
+	std::vector<AdjacentImprovementYieldChange> m_vAdjacentImprovementYieldChanges;
+
 private:
 	CvTraitEntry(const CvTraitEntry&);
 	CvTraitEntry& operator=(const CvTraitEntry&);
@@ -1266,6 +1280,7 @@ public:
 	int GetMovesChangeUnitCombat(const int unitCombatID) const;
 	int GetMaintenanceModifierUnitCombat(const int unitCombatID) const;
 	int GetImprovementYieldChange(ImprovementTypes eImprovement, YieldTypes eYield) const;
+	int GetAdjacentImprovementYieldChange(ImprovementTypes eImprovement, ImprovementTypes eOtherImprovement, YieldTypes eYield) const;
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)
 	int GetPlotYieldChange(PlotTypes ePlot, YieldTypes eYield) const;
 #endif


### PR DESCRIPTION
新增4个来源的 AdjacentImprovementYieldChanges 子表，效果可叠加：
- Policy_AdjacentImprovementYieldChanges
- Trait_AdjacentImprovementYieldChanges
- Belief_AdjacentImprovementYieldChanges（宗教信条解锁，城市级，含第二万神检测）
- Building_AdjacentImprovementYieldChanges（Local）
- Building_AdjacentImprovementYieldChangesGlobal（建筑解锁Global，玩家级）